### PR TITLE
changed module name

### DIFF
--- a/backend/go.mod
+++ b/backend/go.mod
@@ -1,5 +1,4 @@
-module sceats/m
-
+module github.com/SCE-Development/SCEats/backend
 go 1.23.2
 
 require github.com/mattn/go-sqlite3 v1.14.23


### PR DESCRIPTION
The backend requires importing the database, and the module definition didn't allow that. So, I changed it so that I could import that in the backend